### PR TITLE
Fix metrics cache consumer groups information when it in inconsistent state

### DIFF
--- a/udmetrics/src/main/java/com/epam/eco/kafkamanager/udmetrics/UDMetricManager.java
+++ b/udmetrics/src/main/java/com/epam/eco/kafkamanager/udmetrics/UDMetricManager.java
@@ -29,6 +29,8 @@ public interface UDMetricManager {
             UDMetricType type,
             String resourceName,
             Map<String, Object> config);
+    void updateAllFailed();
+    boolean hasErrors();
     void remove(String name);
     UDMetric get(String name);
     Page<UDMetric> page(Pageable pageable);

--- a/udmetrics/src/main/java/com/epam/eco/kafkamanager/udmetrics/UDMetricManagerImpl.java
+++ b/udmetrics/src/main/java/com/epam/eco/kafkamanager/udmetrics/UDMetricManagerImpl.java
@@ -90,6 +90,19 @@ public class UDMetricManagerImpl implements UDMetricManager, UpdateListener {
     }
 
     @Override
+    public void updateAllFailed() {
+        listAll().stream()
+                .filter(UDMetric::hasErrors)
+                .forEach(udMetric -> createOrReplace(udMetric.getType(),
+                                                     udMetric.getResourceName(),
+                                                     udMetric.getConfig()));
+    }
+    @Override
+    public boolean hasErrors() {
+        return listAll().stream().anyMatch(UDMetric::hasErrors);
+    }
+
+    @Override
     public void remove(String name) {
         Validate.notBlank(name, "UDM name is blank");
 

--- a/ui/src/main/java/com/epam/eco/kafkamanager/ui/metrics/udm/UDMetricsController.java
+++ b/ui/src/main/java/com/epam/eco/kafkamanager/ui/metrics/udm/UDMetricsController.java
@@ -40,11 +40,12 @@ public class UDMetricsController extends UDMAbstractController {
     public static final String VIEW = "udmetrics";
 
     public static final String ATTR_PAGE = "page";
-    public static final String ATTR_UDM_NAME = "udmName";
     public static final String ATTR_SEARCH_CRITERIA = "searchCriteria";
     public static final String ATTR_TOTAL_COUNT = "totalCount";
+    public static final String HAS_ERRORS = "hasErrors";
 
     public static final String MAPPING = "/udmetrics";
+    public static final String UPDATE_URL = "updateUrl";
 
     @RequestMapping(value=MAPPING, method=RequestMethod.GET)
     public String metrics(
@@ -65,8 +66,15 @@ public class UDMetricsController extends UDMAbstractController {
         model.addAttribute(ATTR_SEARCH_CRITERIA, searchCriteria);
         model.addAttribute(ATTR_PAGE, wrap(metricPage));
         model.addAttribute(ATTR_TOTAL_COUNT, udMetricManager.getCount());
+        model.addAttribute(HAS_ERRORS, udMetricManager.hasErrors());
 
         return VIEW;
+    }
+
+    @RequestMapping(value=MAPPING, method=RequestMethod.PATCH)
+    public String updateFailed() {
+        udMetricManager.updateAllFailed();
+        return "redirect:/" + VIEW;
     }
 
     private Page<UDMetricWrapper> wrap(Page<UDMetric> page) {

--- a/ui/src/main/resources/templates/udmetrics.html
+++ b/ui/src/main/resources/templates/udmetrics.html
@@ -60,7 +60,10 @@
                 $('#delete-udm-form').prop('action', action);
                 $('#delete-udm-form').submit();
             });
-            
+
+            $('#update-failed-button').click( () => {
+                $('#update-failed-form').submit();
+            });
         });
     </script>
     
@@ -110,6 +113,17 @@
                             class="btn btn-primary">
                             Find
                         </button>
+                        <button
+                            type="button"
+                            id="update-failed-button"
+                            class="btn btn-primary"
+                            th:disabled="${!hasErrors}">
+                            Update failed metrics
+                        </button>
+                    </form>
+                    <form id="update-failed-form" action="/udmetrics" method="post">
+                        <input type="hidden" name="_method" value="patch"/>
+                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
                     </form>
                 </div>
             </div>


### PR DESCRIPTION
Problem occurs when information about metric (topic __eco_udm_configs) exists, but there is no consumer groups created at the moment when kafka-manager was started. And often when consumers  begin read messages from topic, that cause creating consumer groups, kafka-manager doesn't see this consumer groups in metrics page.

To fix it, we have to made a button, witch will be refresh information about consumer groups in a metrics cache, for the failed records.