### PR TITLE
EPMECO-15486 Kafka manager cant delete metric

### DIFF
--- a/ui/src/main/resources/templates/consumer_group.html
+++ b/ui/src/main/resources/templates/consumer_group.html
@@ -171,12 +171,12 @@
                                 <ul class="dropdown-menu">
                                     <li>
                                         <a  class="dropdown-item" th:href="@{/udmetrics/consumer_group_lag/{name}(name=${group.name})}">
-                                            <i class="fa fa-edit"></i> <span th:text="${groupLagUdm != null ? 'Edit' : 'Create'}"></span>
+                                            <i class="fa fa-edit info"></i> <span th:text="${groupLagUdm != null ? 'Edit' : 'Create'}"></span>
                                         </a>
                                     </li>
                                     <li th:if="${groupLagUdm != null}">
-                                        <a class="dropdown-item" href="#" th:attr="data-action=@{${groupLagUdm.url}}">
-                                            <i class="fa fa-trash"></i> Delete
+                                        <a class="dropdown-item delete-udm-link" href="#" th:attr="data-action=@{${groupLagUdm.url}}">
+                                            <i class="fa fa-trash text-danger"></i> Delete
                                         </a>
                                     </li>
                                 </ul>

--- a/ui/src/main/resources/templates/topic.html
+++ b/ui/src/main/resources/templates/topic.html
@@ -378,7 +378,7 @@
                                         </a>
                                     </li>
                                     <li th:if="${topicOffsetIncreaseUdm != null}">
-                                        <a class="dropdown-item" href="#" th:attr="data-action=@{${topicOffsetIncreaseUdm.url}}">
+                                        <a class="dropdown-item delete-udm-link" href="#" th:attr="data-action=@{${topicOffsetIncreaseUdm.url}}">
                                             <i class="fa fa-trash text-danger"></i> Delete
                                         </a>
                                     </li>

--- a/ui/src/main/resources/templates/udmetrics.html
+++ b/ui/src/main/resources/templates/udmetrics.html
@@ -179,12 +179,12 @@
                                             <ul class="dropdown-menu">
                                                 <li>
                                                     <a class="dropdown-item" th:href="@{${udm.url}}">
-                                                        <i class="fa fa-edit"></i> Edit
+                                                        <i class="fa fa-edit info"></i> Edit
                                                     </a>
                                                 </li>
                                                 <li>
-                                                    <a class="dropdown-item" href="#" th:attr="data-action=@{${udm.url}}">
-                                                        <i class="fa fa-trash"></i> Delete
+                                                    <a class="dropdown-item delete-udm-link" href="#" th:attr="data-action=@{${udm.url}}">
+                                                        <i class="fa fa-trash text-danger"></i> Delete
                                                     </a>
                                                 </li>
                                             </ul>


### PR DESCRIPTION
Steps

go to page kafka-manager/consumer_groups/group_name#
press delete button on metric
Expected: metric was deleted

Fact: nothing happens